### PR TITLE
Include themes in dist folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@blui-lab/angular",
-    "version": "1.0.0-alpha.1",
+    "version": "1.0.0-alpha.2",
     "scripts": {
         "ng": "ng",
         "start": "ng serve demo -c development --open",

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -14,6 +14,7 @@ rm -rf ./dist
 
 yarn
 yarn ng build lab -c production
+cp -r ./src/lab/themes ./dist
 
 echo -e "${BLUE}Copying Package Resources${NC}"
 # Do not copy over the package.json, we need to keep the generated package.json made with the ng build command.

--- a/scripts/testArtifacts.sh
+++ b/scripts/testArtifacts.sh
@@ -14,6 +14,8 @@ echo -ne "  license: "
 if [ ! -f ./LICENSE ]; then echo -e "${RED}Not Found${NC}" && exit 1; else echo -e "${GREEN}Found${NC}"; fi
 echo -ne "  package.json: "
 if [ ! -f ./package.json ]; then echo -e "${RED}Not Found${NC}" && exit 1; else echo -e "${GREEN}Found${NC}"; fi
+echo -ne "  blueTheme.json: "
+if [ ! -f ./themes/blueTheme.scss ]; then echo -e "${RED}Not Found${NC}" && exit 1; else echo -e "${GREEN}Found${NC}"; fi
 
 echo -e "\r\n${GREEN}-----------------------------------"
 echo -e "@blui-lab/angular package successfully created"


### PR DESCRIPTION
<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Include the themes folder in the 'dist' folder so it gets published. 
- Our themes don't get built as part of the ng-pkgr build step, so I added a manual copy step.

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- `yarn build:lab` & see the themes folder in the dist output.  This'll be tested when in the showcase app when a new alpha gets published. 
